### PR TITLE
AmberTools/20: Fix problems with CMake and usempi.

### DIFF
--- a/easybuild/easyconfigs/a/Amber/Amber-20.11-foss-2020a-AmberTools-20.15-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-20.11-foss-2020a-AmberTools-20.15-Python-3.8.2.eb
@@ -19,6 +19,7 @@ sources = [
 ]
 patches = [
     '%%(name)s-%s_cmake-locate-netcdf.patch' % local_amber_ver,
+    'AmberTools-%s_fix_missing_MPI_LIBRARY_error.patch' % local_ambertools_ver,
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/a/Amber/Amber-20.11-fosscuda-2020a-AmberTools-20.15-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-20.11-fosscuda-2020a-AmberTools-20.15-Python-3.8.2.eb
@@ -19,6 +19,7 @@ sources = [
 ]
 patches = [
     '%%(name)s-%s_cmake-locate-netcdf.patch' % local_amber_ver,
+    'AmberTools-%s_fix_missing_MPI_LIBRARY_error.patch' % local_ambertools_ver,
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/a/Amber/AmberTools-20_fix_missing_MPI_LIBRARY_error.patch
+++ b/easybuild/easyconfigs/a/Amber/AmberTools-20_fix_missing_MPI_LIBRARY_error.patch
@@ -1,0 +1,21 @@
+When using "usempi" there will be no MPI_xxx_LIBRARIES set and that causes
+import_libraries to error out. We know it is correct so comment out that
+FATAL_ERROR.
+
+Åke Sandgren, 2021-06-16
+diff -ru amber20_src.orig/cmake/LibraryTracking.cmake amber20_src/cmake/LibraryTracking.cmake
+--- amber20_src.orig/cmake/LibraryTracking.cmake	2021-04-25 02:51:44.000000000 +0200
++++ amber20_src/cmake/LibraryTracking.cmake	2021-06-16 13:30:26.568317368 +0200
+@@ -170,9 +170,9 @@
+ 
+ 	cmake_parse_arguments(IMP_LIBS "" "" "LIBRARIES;INCLUDES" ${ARGN})
+ 	
+-	if("${IMP_LIBS_LIBRARIES}" STREQUAL "")
+-		message(FATAL_ERROR "Incorrect usage.  At least one LIBRARY should be provided.")
+-	endif()
++	#if("${IMP_LIBS_LIBRARIES}" STREQUAL "")
++	#	message(FATAL_ERROR "Incorrect usage.  At least one LIBRARY should be provided.")
++	#endif()
+ 	
+ 	if(NOT "${IMP_LIBS_UNPARSED_ARGUMENTS}" STREQUAL "")
+ 		message(FATAL_ERROR "Incorrect usage.  Extra arguments provided.")


### PR DESCRIPTION
When using usempi CMake doesn't define MPI_xxx_LIBRARIES causing AmberTools
import_libraries to error out.