### PR TITLE
Fix test_ops* startup failures

### DIFF
--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.13.1-foss-2022a.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.13.1-foss-2022a.eb
@@ -22,6 +22,7 @@ patches = [
     'PyTorch-1.12.1_fix-vsx-vector-funcs.patch',
     'PyTorch-1.12.1_fix-vsx-loadu.patch',
     'PyTorch-1.12.1_skip-test_round_robin_create_destroy.patch',
+    'PyTorch-1.13.1_fix-pytest-args.patch',
     'PyTorch-1.13.1_fix-test-ops-conf.patch',
     'PyTorch-1.13.1_no-cuda-stubs-rpath.patch',
     'PyTorch-1.13.1_remove-flaky-test-in-testnn.patch',
@@ -46,6 +47,8 @@ checksums = [
     {'PyTorch-1.12.1_fix-vsx-loadu.patch': '8bfe3c94ada1dd1f7974a1261a8b576fb7ae944050fa1c7830fca033831123b2'},
     {'PyTorch-1.12.1_skip-test_round_robin_create_destroy.patch':
      '1435fcac3234edc865479199673b902eb67f6a2bd046af7d731141f03594666d'},
+    {'PyTorch-1.13.1_fix-pytest-args.patch':
+     'd3e3c841cf8d73683750f29326f2be56ee0bb5df7ff522baf7d7c3f301a91ec2'},
     {'PyTorch-1.13.1_fix-test-ops-conf.patch': 'df652eec7753864ebebbfeca546929a53e3fb8f24259d5c9b964266a8551198c'},
     {'PyTorch-1.13.1_no-cuda-stubs-rpath.patch': '4c636059850fc9d1ecb27ce275f8aad5d5b6fdc19e35aff0c25b86cb3201352a'},
     {'PyTorch-1.13.1_remove-flaky-test-in-testnn.patch':
@@ -59,6 +62,9 @@ osdependencies = [OS_PKG_IBVERBS_DEV]
 builddependencies = [
     ('CMake', '3.23.1'),
     ('hypothesis', '6.46.7'),
+    # For tests
+    ('pytest-rerunfailures', '11.1'),
+    ('pytest-shard', '0.1.2'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.13.1_fix-pytest-args.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.13.1_fix-pytest-args.patch
@@ -1,0 +1,28 @@
+As we don't set `--save-xml` pytest is called without arguments causing it to try to discover ALL tests.
+This leads to massive failures in e.g. `test_ops*` where `--use-pytest` is used by the tests.
+See https://github.com/pytorch/pytorch/pull/94589
+
+Author: Alexander Grund (TU Dresden)
+
+diff --git a/torch/testing/_internal/common_utils.py b/torch/testing/_internal/common_utils.py
+index e32850908d4..e63c6f2a392 100644
+--- a/torch/testing/_internal/common_utils.py
++++ b/torch/testing/_internal/common_utils.py
+@@ -737,14 +737,16 @@ def run_tests(argv=UNITTEST_ARGS):
+             failed |= wait_for_process(p) != 0
+         assert not failed, "Some test shards have failed"
+     elif USE_PYTEST:
++        pytest_args = argv
+         if TEST_SAVE_XML:
+             test_report_path = get_report_path(pytest=True)
+             print(f'Test results will be stored in {test_report_path}')
++            pytest_args = pytest_args + [f'--junit-xml-reruns={test_report_path}']
+ 
+         import pytest
+         os.environ["NO_COLOR"] = "1"
+         os.environ["USING_PYTEST"] = "1"
+-        exit_code = pytest.main(args=argv + [f'--junit-xml-reruns={test_report_path}'] if TEST_SAVE_XML else [])
++        exit_code = pytest.main(args=pytest_args)
+         del os.environ["USING_PYTEST"]
+         if TEST_SAVE_XML:
+             sanitize_pytest_xml(test_report_path)


### PR DESCRIPTION
Those tests require 2 pytest plugins and a bugfix.

That bugfix resolves the failures you describe at https://github.com/easybuilders/easybuild-easyconfigs/pull/17155#issuecomment-1396852494

It is basically caused by them (accidentally) running `pytest` in discovery mode over the whole test folder.