### PR TITLE
Ensure `configuremake.py` can be accessed by `hashFiles`

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -47,7 +47,6 @@ jobs:
 
     - name: install EasyBuild framework
       run: |
-          cd $HOME
           # first determine which branch of easybuild-framework repo to install
           BRANCH=develop
           if [ "x$GITHUB_BASE_REF" = 'xmain' ]; then BRANCH=main; fi
@@ -68,17 +67,16 @@ jobs:
       with:
         path: /tmp/sources
         # Ensure cache is invalidated when configuremake.py changes so we download latest version of config.guess
-        key: eb-sourcepath-${{ hashFiles('**/easyblocks/generic/configuremake.py') }}
+        key: eb-sourcepath-${{ matrix.python }}-${{ hashFiles('easybuild-easyblocks/easybuild/easyblocks/generic/configuremake.py') }}
 
     - name: install modules tool
       run: |
-          cd $HOME
           # use install_eb_dep.sh script provided with easybuild-framework
           export INSTALL_DEP=$(which install_eb_dep.sh)
           echo "Found install_eb_dep.sh script: $INSTALL_DEP"
 
           # install modules tool
-          source $INSTALL_DEP ${{matrix.modules_tool}} $HOME
+          source $INSTALL_DEP ${{matrix.modules_tool}} $PWD
 
           # changes in environment are not passed to other steps, so need to create files...
           echo $MOD_INIT > mod_init
@@ -94,13 +92,13 @@ jobs:
           if [ "x$GITHUB_BASE_REF" != 'xmain' ]; then git fetch -v origin ${GITHUB_BASE_REF}:${GITHUB_BASE_REF}; fi
 
           # initialize environment for modules tool
-          if [ -f $HOME/moduleshome ]; then export MODULESHOME=$(cat $HOME/moduleshome); fi
-          source $(cat $HOME/mod_init); type module
+          if [ -f $PWD/moduleshome ]; then export MODULESHOME=$(cat $PWD/moduleshome); fi
+          source $(cat $PWD/mod_init); type module
 
           # make sure 'eb' is available via $PATH, and that $PYTHONPATH is set (some tests expect that);
           # also pick up changes to $PATH set by sourcing $MOD_INIT
           WORKDIR=$GITHUB_WORKSPACE/easybuild-easyconfigs
-          export PATH=$WORKDIR/test/bin:$(cat $HOME/path)
+          export PATH=$WORKDIR/test/bin:$(cat $PWD/path)
           export PYTHONPATH=$WORKDIR
 
           # tell EasyBuild which modules tool is available
@@ -121,7 +119,7 @@ jobs:
 
           # run test suite
           # if tests failed, print error message that is picked up by boegelbot to determine end of test output
-          # python -O -m test.easyconfigs.suite || (echo "ERROR: Not all tests were successful" && exit 1)
+          python -O -m test.easyconfigs.suite || (echo "ERROR: Not all tests were successful" && exit 1)
 
           unset PYTHONPATH
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -47,6 +47,7 @@ jobs:
 
     - name: install EasyBuild framework
       run: |
+          cd $HOME
           # first determine which branch of easybuild-framework repo to install
           BRANCH=develop
           if [ "x$GITHUB_BASE_REF" = 'xmain' ]; then BRANCH=main; fi
@@ -61,22 +62,25 @@ jobs:
           cd easybuild-easyblocks; git log -n 1; cd -
           pip install $PWD/easybuild-easyblocks
 
+          cp easybuild-easyblocks/easybuild/easyblocks/generic/configuremake.py $GITHUB_WORKSPACE/configuremake.check
+
     - name: Restore cache of source files in /tmp/sources
       id: restore-cache-sources
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # 6.1.0
       with:
         path: /tmp/sources
         # Ensure cache is invalidated when configuremake.py changes so we download latest version of config.guess
-        key: eb-sourcepath-${{ matrix.python }}-${{ hashFiles('easybuild-easyblocks/easybuild/easyblocks/generic/configuremake.py') }}
+        key: eb-sourcepath-${{ matrix.python }}-${{ hashFiles('configuremake.check') }}
 
     - name: install modules tool
       run: |
+          cd $HOME
           # use install_eb_dep.sh script provided with easybuild-framework
           export INSTALL_DEP=$(which install_eb_dep.sh)
           echo "Found install_eb_dep.sh script: $INSTALL_DEP"
 
           # install modules tool
-          source $INSTALL_DEP ${{matrix.modules_tool}} $PWD
+          source $INSTALL_DEP ${{matrix.modules_tool}} $HOME
 
           # changes in environment are not passed to other steps, so need to create files...
           echo $MOD_INIT > mod_init
@@ -92,13 +96,13 @@ jobs:
           if [ "x$GITHUB_BASE_REF" != 'xmain' ]; then git fetch -v origin ${GITHUB_BASE_REF}:${GITHUB_BASE_REF}; fi
 
           # initialize environment for modules tool
-          if [ -f $PWD/moduleshome ]; then export MODULESHOME=$(cat $PWD/moduleshome); fi
-          source $(cat $PWD/mod_init); type module
+          if [ -f $HOME/moduleshome ]; then export MODULESHOME=$(cat $HOME/moduleshome); fi
+          source $(cat $HOME/mod_init); type module
 
           # make sure 'eb' is available via $PATH, and that $PYTHONPATH is set (some tests expect that);
           # also pick up changes to $PATH set by sourcing $MOD_INIT
           WORKDIR=$GITHUB_WORKSPACE/easybuild-easyconfigs
-          export PATH=$WORKDIR/test/bin:$(cat $PWD/path)
+          export PATH=$WORKDIR/test/bin:$(cat $HOME/path)
           export PYTHONPATH=$WORKDIR
 
           # tell EasyBuild which modules tool is available


### PR DESCRIPTION
- Copy `configuremake.py` in `GITHUB_WORKSPACE` as `configuremake.check` (avoid `py` extension to not risk weird behaviors) so that hashFiles can work
- Use the correct path for `hashFiles`

Test that the cache is working:
https://github.com/Crivella/easybuild-easyconfigs/pull/4